### PR TITLE
feat: Adds transactional outbox setup and trigger

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -265,6 +265,55 @@ function :: The name of the trigger function to call to log changes
 Note that it is probably a bad idea to use the same table argument
 to both +pgt_json_audit_log_setup+ and +pgt_json_audit_log+.
 
+=== Transactional Outbox Events - pgt_outbox_setup and pgt_outbox_events
+
+These methods setup an outbox table and write events to it when
+writes happen to the watched table.
+
+==== pgt_outbox_setup
+
+This creates an outbox table and a trigger function that will write
+event data to the outbox table. This returns the name of the
+trigger function created, which should be passed to
++pgt_outbox_events+.
+
+Arguments:
+table :: The name of the table storing the audit logs.
+
+Options:
+function_name :: The name of the trigger function
+outbox_table :: The name for the outbox table. Defaults to table_outbox
+event_prefix :: The prefix to use for event_type, defaults to table_ (table_updated, table_created, table_deleted)
+boolean_completed_column :: If this is true, the :completed column will be boolean, otherwise it will be timestamptz
+uuid_primary_key :: Use a uuid type for the primary key of the outbox table
+uuid_function :: The pl/pgsql function name to use for generating a uuid pkey. defaults to :generate_uuid_v4
+function_opts :: Options to pass to +create_function+ when creating the trigger function.
+Column Name Options: (column type in parenthesis)
+created_column :: defaults to :created (timestamptz)
+updated_column :: defaults to :updated (timestamptz)
+attempts_column :: defaults to :attempts (Integer)
+attempted_column :: defaults to :attempted (timestamptz)
+completed_column :: defaults to :completed (Boolean or timestamptz, depending on :boolean_completed_column)
+event_type_column :: defaults to :event_type (String)
+last_error_column :: defaults to :last_error (String)
+data_before_column :: defaults to :data_before (jsonb)
+data_after_column :: defaults to :data_after (jsonb)
+metadata_column :: defaults to :metadata (jsonb)
+
+==== pgt_outbox_events
+
+This adds a trigger to the table that will store events in the outbox table
+when updates occur on the table (and match the filter).
+
+Arguments:
+table :: The name of the table to audit
+function :: The name of the trigger function to call to log changes (usually returned from pgt_outbox_setup)
+
+Options:
+events :: The events to care about. Defaults to [:updated, :deleted, :created] (all writes)
+trigger_name :: The name for the trigger
+when :: A filter for the trigger, where clause if you will
+
 == Caveats
 
 If you have defined counter or sum cache triggers using this library

--- a/lib/sequel/extensions/pg_triggers.rb
+++ b/lib/sequel/extensions/pg_triggers.rb
@@ -330,6 +330,8 @@ module Sequel
         created_column = opts.fetch(:created_column, :created)
         updated_column = opts.fetch(:updated_column, :updated)
         event_type_column = opts.fetch(:event_type_column, :event_type)
+        data_after_column = opts.fetch(:data_after_column, :data_after)
+        data_before_column = opts.fetch(:data_before_column, :data_before)
         boolean_completed_column = opts.fetch(:boolean_completed_column, false)
         uuid_primary_key = opts.fetch(:uuid_primary_key, false)
         run 'CREATE EXTENSION IF NOT EXISTS "uuid-ossp"' if uuid_primary_key
@@ -351,8 +353,8 @@ module Sequel
           end
           String event_type_column, null: false
           String opts.fetch(:last_error_column, :last_error)
-          jsonb  opts.fetch(:data_before_column, :data_before)
-          jsonb  opts.fetch(:data_after_column, :data_after)
+          jsonb  data_before_column
+          jsonb  data_after_column
           jsonb  opts.fetch(:metadata_column, :metadata)
         end
         pgt_created_at outbox_table, created_column

--- a/lib/sequel/extensions/pg_triggers.rb
+++ b/lib/sequel/extensions/pg_triggers.rb
@@ -328,15 +328,15 @@ module Sequel
         quoted_outbox = quote_schema_table(outbox_table)
         event_prefix  = opts.fetch(:event_prefix, table)
         created_column = opts.fetch(:created_column, :created)
-        created_column = opts.fetch(:updated_column, :updated)
+        updated_column = opts.fetch(:updated_column, :updated)
         event_type_column = opts.fetch(:event_type_column, :event_type)
-        boolean_attempted_column = opts.fetch(:boolean_attempted_column, false)
-        uuid_primary_key = opts.fetch(:outbox_uuid_primary_key, false)
-        run 'CREATE EXTENSION IF NOT EXISTS "uuid-ossp"' if uuid_column
+        boolean_completed_column = opts.fetch(:boolean_completed_column, false)
+        uuid_primary_key = opts.fetch(:uuid_primary_key, false)
+        run 'CREATE EXTENSION IF NOT EXISTS "uuid-ossp"' if uuid_primary_key
         create_table(outbox_table) do
           if uuid_primary_key
-            uuid_function = opts.fetch(:outbox_uuid_function, :generate_uuid_v4)
-            uuid :id, :default=>Sequel.function(uuid_function), :primary_key=>true
+            uuid_function = opts.fetch(:uuid_function, :generate_uuid_v4)
+            uuid :id, default: Sequel.function(uuid_function), primary_key: true
           else
             primary_key :id
           end
@@ -381,7 +381,7 @@ module Sequel
       def pgt_outbox_events(table, function, opts={})
         events = opts.fetch(:events, [:insert, :update, :delete])
         trigger_name = opts.fetch(:trigger_name, "pgt_outbox_#{pgt_mangled_table_name(table)}")
-        create_trigger(table, trigger_name, function, events:, replace: true, each_row: true, after: true, when: opts[:when])
+        create_trigger(table, trigger_name, function, events: events, replace: true, each_row: true, after: true, when: opts[:when])
       end
 
       private

--- a/lib/sequel/extensions/pg_triggers.rb
+++ b/lib/sequel/extensions/pg_triggers.rb
@@ -322,6 +322,68 @@ module Sequel
         SQL
       end
 
+      def pgt_outbox_setup(table, opts={})
+        function_name = opts.fetch(:function_name, "pgt_outbox_#{pgt_mangled_table_name(table)}")
+        outbox_table  = opts.fetch(:outbox_table, "#{table}_outbox")
+        quoted_outbox = quote_schema_table(outbox_table)
+        event_prefix  = opts.fetch(:event_prefix, table)
+        created_column = opts.fetch(:created_column, :created)
+        created_column = opts.fetch(:updated_column, :updated)
+        event_type_column = opts.fetch(:event_type_column, :event_type)
+        boolean_attempted_column = opts.fetch(:boolean_attempted_column, false)
+        uuid_primary_key = opts.fetch(:outbox_uuid_primary_key, false)
+        run 'CREATE EXTENSION IF NOT EXISTS "uuid-ossp"' if uuid_column
+        create_table(outbox_table) do
+          if uuid_primary_key
+            uuid_function = opts.fetch(:outbox_uuid_function, :generate_uuid_v4)
+            uuid :id, :default=>Sequel.function(uuid_function), :primary_key=>true
+          else
+            primary_key :id
+          end
+          Integer opts.fetch(:attempts_column, :attempts), null: false, default: 0
+          column  created_column, :timestamptz
+          column  updated_column, :timestamptz
+          column  opts.fetch(:attempted_column, :attempted), :timestamptz
+          if opts[:boolean_completed_column]
+            FalseClass opts.fetch(:completed_column, :completed), null: false, default: false
+          else
+            column     opts.fetch(:completed_column, :completed), :timestamptz
+          end
+          String event_type_column, null: false
+          String opts.fetch(:last_error_column, :last_error)
+          jsonb  opts.fetch(:data_before_column, :data_before)
+          jsonb  opts.fetch(:data_after_column, :data_after)
+          jsonb  opts.fetch(:metadata_column, :metadata)
+        end
+        pgt_created_at outbox_table, created_column
+        pgt_updated_at outbox_table, updated_column
+        create_function(function_name, (<<-SQL), {:language=>:plpgsql, :returns=>:trigger, :replace=>true}.merge(opts[:function_opts]||{}))
+        BEGIN
+          #{pgt_pg_trigger_depth_guard_clause(opts)}
+          IF (TG_OP = 'INSERT') THEN
+              INSERT INTO #{quoted_outbox} ("#{event_type_column}", "#{data_after_column}") VALUES
+              ('#{event_prefix}_created', to_jsonb(NEW));
+              RETURN NEW;
+          ELSIF (TG_OP = 'UPDATE') THEN
+              INSERT INTO #{quoted_outbox} ("#{event_type_column}", "#{data_before_column}", "#{data_after_column}") VALUES
+              ('#{event_prefix}_updated', to_jsonb(OLD), to_jsonb(NEW));
+              RETURN NEW;
+          ELSIF (TG_OP = 'DELETE') THEN
+              INSERT INTO #{quoted_outbox} ("#{event_type_column}", "#{data_before_column}") VALUES
+              ('#{event_prefix}_deleted', to_jsonb(OLD));
+              RETURN OLD;
+          END IF;
+        END;
+        SQL
+        function_name
+      end
+
+      def pgt_outbox_events(table, function, opts={})
+        events = opts.fetch(:events, [:insert, :update, :delete])
+        trigger_name = opts.fetch(:trigger_name, "pgt_outbox_#{pgt_mangled_table_name(table)}")
+        create_trigger(table, trigger_name, function, events:, replace: true, each_row: true, after: true, when: opts[:when])
+      end
+
       private
 
       # Add or replace a function that returns trigger to handle the action,

--- a/lib/sequel/extensions/pg_triggers.rb
+++ b/lib/sequel/extensions/pg_triggers.rb
@@ -344,7 +344,7 @@ module Sequel
           column  created_column, :timestamptz
           column  updated_column, :timestamptz
           column  opts.fetch(:attempted_column, :attempted), :timestamptz
-          if opts[:boolean_completed_column]
+          if boolean_completed_column
             FalseClass opts.fetch(:completed_column, :completed), null: false, default: false
           else
             column     opts.fetch(:completed_column, :completed), :timestamptz

--- a/lib/sequel/extensions/pg_triggers.rb
+++ b/lib/sequel/extensions/pg_triggers.rb
@@ -337,7 +337,7 @@ module Sequel
         run 'CREATE EXTENSION IF NOT EXISTS "uuid-ossp"' if uuid_primary_key
         create_table(outbox_table) do
           if uuid_primary_key
-            uuid_function = opts.fetch(:uuid_function, :generate_uuid_v4)
+            uuid_function = opts.fetch(:uuid_function, :uuid_generate_v4)
             uuid :id, default: Sequel.function(uuid_function), primary_key: true
           else
             primary_key :id

--- a/spec/sequel_postgresql_triggers_spec.rb
+++ b/spec/sequel_postgresql_triggers_spec.rb
@@ -25,7 +25,7 @@ if ENV['PGT_GLOBAL'] == '1'
   require 'sequel_postgresql_triggers'
 else
   puts "Running specs with extension"
-  DB.extension :pg_triggers 
+  DB.extension :pg_triggers
 end
 DB.extension :pg_array
 
@@ -59,31 +59,31 @@ describe "PostgreSQL Counter Cache Trigger" do
 
     DB[:entries].insert(:id=>2, :account_id=>1)
     DB[:accounts].order(:id).select_map(:num_entries).must_equal [2, 0]
-    
+
     DB[:entries].insert(:id=>3, :account_id=>nil)
     DB[:accounts].order(:id).select_map(:num_entries).must_equal [2, 0]
-    
+
     DB[:entries].where(:id=>3).update(:account_id=>2)
     DB[:accounts].order(:id).select_map(:num_entries).must_equal [2, 1]
-    
+
     DB[:entries].where(:id=>2).update(:account_id=>2)
     DB[:accounts].order(:id).select_map(:num_entries).must_equal [1, 2]
-    
+
     DB[:entries].where(:id=>2).update(:account_id=>nil)
     DB[:accounts].order(:id).select_map(:num_entries).must_equal [1, 1]
-    
+
     DB[:entries].where(:id=>2).update(:id=>4)
     DB[:accounts].order(:id).select_map(:num_entries).must_equal [1, 1]
-    
+
     DB[:entries].where(:id=>4).update(:account_id=>2)
     DB[:accounts].order(:id).select_map(:num_entries).must_equal [1, 2]
-    
+
     DB[:entries].where(:id=>4).update(:account_id=>nil)
     DB[:accounts].order(:id).select_map(:num_entries).must_equal [1, 1]
-    
+
     DB[:entries].filter(:id=>4).delete
     DB[:accounts].order(:id).select_map(:num_entries).must_equal [1, 1]
-    
+
     DB[:entries].delete
     DB[:accounts].order(:id).select_map(:num_entries).must_equal [0, 0]
   end
@@ -195,34 +195,34 @@ describe "PostgreSQL Sum Cache Trigger" do
 
     DB[:entries].insert(:id=>2, :account_id=>1, :amount=>200)
     DB[:accounts].order(:id).select_map(:balance).must_equal [300, 0]
-    
+
     DB[:entries].insert(:id=>3, :account_id=>nil, :amount=>500)
     DB[:accounts].order(:id).select_map(:balance).must_equal [300, 0]
-    
+
     DB[:entries].where(:id=>3).update(:account_id=>2)
     DB[:accounts].order(:id).select_map(:balance).must_equal [300, 500]
-    
+
     DB[:entries].exclude(:id=>2).update(:amount=>Sequel.*(:amount, 2))
     DB[:accounts].order(:id).select_map(:balance).must_equal [400, 1000]
-    
+
     DB[:entries].where(:id=>2).update(:account_id=>2)
     DB[:accounts].order(:id).select_map(:balance).must_equal [200, 1200]
-    
+
     DB[:entries].where(:id=>2).update(:account_id=>nil)
     DB[:accounts].order(:id).select_map(:balance).must_equal [200, 1000]
-    
+
     DB[:entries].where(:id=>2).update(:id=>4)
     DB[:accounts].order(:id).select_map(:balance).must_equal [200, 1000]
-    
+
     DB[:entries].where(:id=>4).update(:account_id=>2)
     DB[:accounts].order(:id).select_map(:balance).must_equal [200, 1200]
-    
+
     DB[:entries].where(:id=>4).update(:account_id=>nil)
     DB[:accounts].order(:id).select_map(:balance).must_equal [200, 1000]
-    
+
     DB[:entries].filter(:id=>4).delete
     DB[:accounts].order(:id).select_map(:balance).must_equal [200, 1000]
-    
+
     DB[:entries].delete
     DB[:accounts].order(:id).select_map(:balance).must_equal [0, 0]
   end
@@ -747,6 +747,7 @@ describe "PostgreSQL Force Defaults Trigger" do
     DB[:accounts].first.must_equal(:id=>10, :a=>1, :b=>"'\\a", :c=>nil, :d=>14)
   end
 end
+
 describe "PostgreSQL JSON Audit Logging" do
   before do
     DB.extension :pg_json
@@ -785,12 +786,13 @@ describe "PostgreSQL JSON Audit Logging" do
     txid2.must_be :>, txid1
     h.must_equal(:schema=>"public", :table=>"accounts", :action=>"DELETE", :prior=>{"a"=>3, "id"=>2})
   end
+end if DB.server_version >= 90400
 
 describe "PostgreSQL Transactional Outbox" do
   before do
     DB.extension :pg_json
     DB.create_table(:accounts){integer :id; String :s}
-    function_name = DB.pgt_outbox_setup(:accounts_outbox, :function_name=>:spgt_outbox_events)
+    function_name = DB.pgt_outbox_setup(:accounts, :function_name=>:spgt_outbox_events)
     DB.pgt_outbox_events(:accounts, function_name)
     @logs = DB[:accounts_outbox].reverse(:created)
   end
@@ -808,18 +810,21 @@ describe "PostgreSQL Transactional Outbox" do
     ds.all.must_equal [{id: 1, s: 'string'}]
     h = @logs.first
     h.delete(:created).to_i.must_be_close_to(10, DB.get(Sequel::CURRENT_TIMESTAMP).to_i)
-    h.must_equal({})
+    h.delete(:updated).to_i.must_be_close_to(10, DB.get(Sequel::CURRENT_TIMESTAMP).to_i)
+    h.must_equal(id: 1, attempts: 0, attempted: nil, completed: nil, event_type: "accounts_created", last_error: nil, data_before: nil, data_after: {"s" => "string", "id" => 1}, metadata: nil)
 
-    @ds.where(id: 1).update(s: 'string2')
-    @ds.all.must_equal [{id: 1, s: 'string2'}]
+    ds.where(id: 1).update(s: 'string2')
+    ds.all.must_equal [{id: 1, s: 'string2'}]
     h = @logs.first
     h.delete(:created).to_i.must_be_close_to(10, DB.get(Sequel::CURRENT_TIMESTAMP).to_i)
-    h.must_equal({})
+    h.delete(:updated).to_i.must_be_close_to(10, DB.get(Sequel::CURRENT_TIMESTAMP).to_i)
+    h.must_equal(id: 2, attempts: 0, attempted: nil, completed: nil, event_type: "accounts_updated", last_error: nil, data_before: {"s" => "string", "id" => 1}, data_after: {"s" => "string2", "id" => 1}, metadata: nil)
 
-    @ds.delete
-    @ds.all.must_equal []
+    ds.delete
+    ds.all.must_equal []
     h = @logs.first
     h.delete(:created).to_i.must_be_close_to(10, DB.get(Sequel::CURRENT_TIMESTAMP).to_i)
-    h.must_equal({})
+    h.delete(:updated).to_i.must_be_close_to(10, DB.get(Sequel::CURRENT_TIMESTAMP).to_i)
+    h.must_equal(id: 3, attempts: 0, attempted: nil, completed: nil, event_type: "accounts_deleted", last_error: nil, data_before: {"s" => "string2", "id" => 1}, data_after: nil, metadata: nil)
   end
 end if DB.server_version >= 90400


### PR DESCRIPTION
This adds a trigger which implements a basic transactional outbox pattern.

Inspired by https://event-driven.io/en/outbox_inbox_patterns_and_delivery_guarantees_explained/ and https://gitlab.com/os85/tobox#usage